### PR TITLE
Print tag/short commit hash to screen and logfile. Fixes #23

### DIFF
--- a/klustakwik.cpp
+++ b/klustakwik.cpp
@@ -1814,6 +1814,7 @@ int main(int argc, char **argv)
     scalar BestScore = HugeScore;
     integer p, i;
     SetupParams((integer)argc, argv); // This function is defined in parameters.cpp
+	Output("Starting KlustaKwik. Version: %s\n", VERSION);
 	if (RamLimitGB == 0.0)
 	{
 		RamLimitGB = (1.0*available_physical_memory()) / (1024.0*1024.0*1024.0);

--- a/klustakwik.cpp
+++ b/klustakwik.cpp
@@ -2,6 +2,10 @@
 //
 // Fast clustering using the CEM algorithm with Masks.
 
+#ifndef VERSION
+#define VERSION "0.3.0-nogit"
+#endif
+
 // Disable some Visual Studio warnings
 #define _CRT_SECURE_NO_WARNINGS
 

--- a/makefile
+++ b/makefile
@@ -15,6 +15,9 @@ endif
 
 CFLAGS = -Wall -c -Wno-write-strings $(OPTIMISATIONS) $(OPENMPFLAG)
 LFLAGS = -Wall $(OPENMPFLAG)
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+CFLAGS = -Wall -c -Wno-write-strings $(OPTIMISATIONS) -DVERSION=\"$(GIT_VERSION)\"
+LFLAGS = -Wall
 
 all: executable
 

--- a/makefile
+++ b/makefile
@@ -6,6 +6,7 @@ CC = g++
 DEBUG = -g
 PROFILE = -pg
 OPTIMISATIONS = -O3 -ffast-math -march=native
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
 
 ifdef NOOPENMP
 OPENMPFLAG =
@@ -13,12 +14,14 @@ else
 OPENMPFLAG = -fopenmp
 endif
 
+# If the git command failed, GIT_VERSION will be empty, so don't pass a DVERSION flag (fallback)
+ifeq ($(strip $(GIT_VERSION)),)
 CFLAGS = -Wall -c -Wno-write-strings $(OPTIMISATIONS) $(OPENMPFLAG)
+else
+CFLAGS = -Wall -c -Wno-write-strings $(OPTIMISATIONS) $(OPENMPFLAG) -DVERSION=\"$(GIT_VERSION)\"
+endif
+
 LFLAGS = -Wall $(OPENMPFLAG)
-FALLBACK_VERSION = "0.3.0-no-git"
-GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags || echo "$(FALLBACK_VERSION)")
-CFLAGS = -Wall -c -Wno-write-strings $(OPTIMISATIONS) -DVERSION=\"$(GIT_VERSION)\"
-LFLAGS = -Wall
 
 all: executable
 

--- a/makefile
+++ b/makefile
@@ -15,7 +15,8 @@ endif
 
 CFLAGS = -Wall -c -Wno-write-strings $(OPTIMISATIONS) $(OPENMPFLAG)
 LFLAGS = -Wall $(OPENMPFLAG)
-GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+FALLBACK_VERSION = "0.3.0-no-git"
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags || echo "$(FALLBACK_VERSION)")
 CFLAGS = -Wall -c -Wno-write-strings $(OPTIMISATIONS) -DVERSION=\"$(GIT_VERSION)\"
 LFLAGS = -Wall
 


### PR DESCRIPTION
This adds a CFLAG to pass the latest tag followed by a short commit hash and print this out to the .klg file and screen.

This prints out the value of:
```git describe --abbrev=4 --dirty --always --tags```

An example might be: ```november_2014_single_processor-14-g9af1-dirty```

which means: ```14``` commits past ```november_2014_single_processor```, git commit beginning in ```9af1```, and the ```-dirty``` indicates that there are uncommitted changes.