### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/klustakwik.cpp
+++ b/klustakwik.cpp
@@ -1516,7 +1516,7 @@ scalar KK::CEM(char *CluFile, integer Recurse, integer InitRand,
         if(Verbose>=1)
         {
             if(Recurse==0) Output("\t\tSP:");
-            if ((Recurse!=0)||(SplitInfo==1&&Recurse==0))
+            if ((Recurse!=0)||(SplitInfo==1))
                 Output("Iteration %d%c (" SCALARFMT " sec): %d clusters\n",
 				       (int)Iter, FullStep ? 'F' : 'Q', timesofar, (int)nClustersAlive);
         }

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -171,7 +171,7 @@ void print_params(FILE *fp)
     add_param(BOOLEAN, "help", &help);
     if (help)
     {
-        fprintf(fp, HelpString);
+        fprintf(fp, "%s\n", HelpString);
         PARAMETERS_TABLE(PRINT_PARAMETERS);
         exit(0);
     }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V618](https://www.viva64.com/en/w/v618/) It's dangerous to call the 'fprintf' function in such a manner, as the line being passed could contain format specification. The example of the safe code: printf("%s", str); parameters.cpp 174
[V728](https://www.viva64.com/en/w/v728/) An excessive check 'Recurse == 0' can be simplified. The '||' operator is surrounded by opposite expressions. klustakwik.cpp 1519